### PR TITLE
Add missing required owners field to AMI search

### DIFF
--- a/server.tf
+++ b/server.tf
@@ -14,7 +14,7 @@ data "template_file" "nessus-user-data" {
 # Find the latest AMI by product code
 data "aws_ami" "nessus-image" {
   most_recent = true
-  owners = ["679593333241"]
+  owners = ["aws-marketplace"]
 
   filter {
     name   = "product-code"

--- a/server.tf
+++ b/server.tf
@@ -14,6 +14,7 @@ data "template_file" "nessus-user-data" {
 # Find the latest AMI by product code
 data "aws_ami" "nessus-image" {
   most_recent = true
+  owners = ["679593333241"]
 
   filter {
     name   = "product-code"


### PR DESCRIPTION
Per https://github.com/hashicorp/packer/issues/6584, owners field is now a required field. This PR adds the owners field hard-coded to the AWS Marketplace account id (679593333241)